### PR TITLE
Increase foolproofness of production deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -139,6 +139,16 @@ set :keep_releases, 5
 # set :npm_prune_flags, ''
 
 namespace :deploy do
+  before "git:check", :alert_deploying_to_stage do
+    on roles(:all) do |host|
+      colors = SSHKit::Color.new($stdout)
+      message = "You are about to deploy to #{fetch(:stage)}"
+      if fetch(:stage) == :production
+        info colors.colorize("\e[5m#{message}!\e[0m", :red)
+      end
+    end
+  end
+
   before :starting, :set_command_map_paths do
     # Koha shell??
     #SSHKit.config.command_map[:composer] = "php #{shared_path.join("composer.phar")}"

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -12,6 +12,7 @@ server 'koha.ub.gu.se',
 set :deploy_to, '/home/koha/koha-production'
 set :keep_releases, 5
 
+set :branch, ''
 #release_prefix = 'release-2018.04-'
 #set :koha_deploy_branches_prefix, release_prefix
 #set :koha_deploy_release_branch_prefix, release_prefix


### PR DESCRIPTION
Make production warning stand out more with annoying blinking text
and force user to manually input branch to deploy